### PR TITLE
Update for v1.5.0 release

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+* text=auto
+
+meta.yaml text eol=lf
+build.sh text eol=lf
+bld.bat text eol=crlf

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,10 @@ osx_image: beta-xcode6.1
 env:
   matrix:
     
-    - CONDA_PY=35
+    - CONDA_NPY=110  CONDA_PY=27
+    - CONDA_NPY=111  CONDA_PY=27
+    - CONDA_NPY=110  CONDA_PY=35
+    - CONDA_NPY=111  CONDA_PY=35
   global:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     - secure: "UqmgH3yFjLodEHkEo8eHt4sLqmeTBNvjW1kPlnZTg1PT9ESzM0u9a32IG1hSpJrJFiRPVNzySMFOep4iPrxfgOpTgVw1eFP/WcvLw43vuOTEKn/vCnGqEbKt/jurJvbkyMcLkGK7xm/eLoxT1i/2fA2L56+uYPJdMAVFZKsfDmngURjDmEBCpP0xnNNay69gS22aiSiflka+YSgcZMYNUbfnhxotM91oLpwqAzcXHOIwFajV8MTq1sVSTf2fuQPN5qr1KgPCxI0NhP5m6+yEd+5sW/YclhpFKqyF0dAAdhCndhepzw+386ZuwrCTezdwlvZ4HMRvWqr2hRoxcvCu6isKO5ZRodyPJ3gRB0Tnnx9mKqTAIboi2p+oybDYgRCViYx/pT/8NqqTxauks1HQ+U33rLqPMtXs2p6Kg1ZSvvi+UrLSTYpjLAQNX2yMqK9xDzxI6EMaFsv3tR9n3F2DzinRy0+Ahp7MEMgMkuT1C59+9NwHVsLpugFTnDayUdTsAEIIVHx9px2a/UNloLDyKzZZ1cB1+P2BQ1iP09b4ijFt1UB8W/Ax5trSfi/LXuUtSEFlOMMRAgtrjolA8oMgjlF653/vLmOqquNYTugzOJpOBUjA2ijMMmOV0uqYg48+9WBXQ1Sw4qY+hngR16RO030uswEvC8l22bNFJdC1XZI="
@@ -34,7 +37,14 @@ install:
       conda install --yes --quiet conda-forge-build-setup
       source run_conda_forge_build_setup
 
+      # install conda-build 2.x to build with a long prefix
+      conda install --yes --quiet conda-build=2
+      conda info
+
 script:
   - conda build ./recipe
 
   - upload_or_check_non_existence ./recipe conda-forge --channel=main
+
+  # inspect the prefix lengths of the built packages
+  - conda inspect prefix-lengths /Users/travis/miniconda3/conda-bld/osx-64/*.tar.bz2

--- a/README.md
+++ b/README.md
@@ -11,6 +11,18 @@ Summary: The agent-based fuel cycle simulator.
 
 
 
+Current build status
+====================
+
+Linux: [![Circle CI](https://circleci.com/gh/conda-forge/cyclus-feedstock.svg?style=shield)](https://circleci.com/gh/conda-forge/cyclus-feedstock)
+OSX: [![TravisCI](https://travis-ci.org/conda-forge/cyclus-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/cyclus-feedstock)
+Windows: ![](https://cdn.rawgit.com/conda-forge/conda-smithy/90845bba35bec53edac7a16638aa4d77217a3713/conda_smithy/static/disabled.svg)
+
+Current release info
+====================
+Version: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/cyclus/badges/version.svg)](https://anaconda.org/conda-forge/cyclus)
+Downloads: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/cyclus/badges/downloads.svg)](https://anaconda.org/conda-forge/cyclus)
+
 Installing cyclus
 =================
 
@@ -31,7 +43,6 @@ It is possible to list all of the versions of `cyclus` available on your platfor
 ```
 conda search cyclus --channel conda-forge
 ```
-
 
 
 About conda-forge
@@ -67,18 +78,6 @@ Terminology
 
 **conda-forge** - the place where the feedstock and smithy live and work to
                   produce the finished article (built conda distributions)
-
-Current build status
-====================
-
-Linux: [![Circle CI](https://circleci.com/gh/conda-forge/cyclus-feedstock.svg?style=shield)](https://circleci.com/gh/conda-forge/cyclus-feedstock)
-OSX: [![TravisCI](https://travis-ci.org/conda-forge/cyclus-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/cyclus-feedstock)
-Windows: ![](https://cdn.rawgit.com/conda-forge/conda-smithy/90845bba35bec53edac7a16638aa4d77217a3713/conda_smithy/static/disabled.svg)
-
-Current release info
-====================
-Version: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/cyclus/badges/version.svg)](https://anaconda.org/conda-forge/cyclus)
-Downloads: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/cyclus/badges/downloads.svg)](https://anaconda.org/conda-forge/cyclus)
 
 
 Updating cyclus-feedstock

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -41,10 +41,39 @@ conda clean --lock
 conda install --yes --quiet conda-forge-build-setup
 source run_conda_forge_build_setup
 
-# Embarking on 1 case(s).
+# install conda-build 2.x to build a long prefix
+conda install --yes --quiet conda-build=2
+conda info
+
+# Embarking on 4 case(s).
     set -x
+    export CONDA_NPY=110
+    export CONDA_PY=27
+    set +x
+    conda build /recipe_root --quiet || exit 1
+    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
+
+    set -x
+    export CONDA_NPY=111
+    export CONDA_PY=27
+    set +x
+    conda build /recipe_root --quiet || exit 1
+    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
+
+    set -x
+    export CONDA_NPY=110
     export CONDA_PY=35
     set +x
     conda build /recipe_root --quiet || exit 1
     upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
+
+    set -x
+    export CONDA_NPY=111
+    export CONDA_PY=35
+    set +x
+    conda build /recipe_root --quiet || exit 1
+    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
+
+# inspect the prefix lengths of the built packages
+conda inspect prefix-lengths /feedstock_root/build_artefacts/linux-64/*.tar.bz2
 EOF

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
 
 build:
   number: 0
-  skip: True  # [win or not py35]
+  skip: True  # [win or not (py27 or py35)]
   detect_binary_files_with_prefix: true
   features:
     - blas_{{ variant }}
@@ -25,33 +25,37 @@ requirements:
     - toolchain
     - python
     - cython
-    - numpy
     - pandas
     - cmake
     - pkg-config
     - libxmlpp
     - coincbc
     - blas 1.1 {{ variant }}
-    - openblas 0.2.18|0.2.18.*
-    - boost 1.61.*
+    - openblas 0.2.19|0.2.19.*
+    - boost 1.62.*
     - hdf5 1.8.17|1.8.17.*
     - sqlite 3.13.*
     - pcre
     - gettext
     - bzip2 1.0.*
     - xz 5.2.*
+    - jinja2
+    - numpy x.x
   run:
+    - python
     - libxmlpp
     - coincbc
     - blas 1.1 {{ variant }}
-    - openblas 0.2.18|0.2.18.*
-    - boost 1.61.*
+    - openblas 0.2.19|0.2.19.*
+    - boost 1.62.*
     - hdf5 1.8.17|1.8.17.*
     - sqlite 3.13.*
     - pcre
     - gettext
     - bzip2 1.0.*
     - xz 5.2.*
+    - numpy x.x
+    - pandas
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 3
+  number: 1
   skip: True  # [win or not py35]
   detect_binary_files_with_prefix: true
   features:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
-{% set version = "1.4.0" %}
+{% set version = "1.5.0" %}
 {% set org = "cyclus" %}
 {% set branch = "master" %}
-{% set sha256 = "9b4cb57a1c67329d7b312bd038893de4e82ade2e822ba33a3b2ff7c14beca7da" %}
+{% set sha256 = "1feee832b0c7284c0e1dce11c58da109f9d3955b2f8b38ce3090ce08ef2fc2c1" %}
 {% set variant = "openblas" %}
 
 package:
@@ -24,6 +24,9 @@ requirements:
   build:
     - toolchain
     - python
+    - cython
+    - numpy
+    - pandas
     - cmake
     - pkg-config
     - libxmlpp

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 0
   skip: True  # [win or not py35]
   detect_binary_files_with_prefix: true
   features:

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -49,3 +49,4 @@ nosetests test_include_recipe.py  test_lotka_volterra.py
 nosetests test_null_sink.py  test_source_to_sink.py
 nosetests test_trivial_cycle.py test_inventories.py
 nosetests test_minimal_cycle.py
+nosetests test_cycluslib.py


### PR DESCRIPTION
This should be everything required:
* updated the version
* updated the sha256 to match the current archive of `master`
* added dependencies: cython, numpy, pandas (not sure what versions matter?)

Curious: why pull the tarball from `master` rather than the release?