### PR TITLE
Change target label to `cyclus_dev`

### DIFF
--- a/.ci_support/linux_64_numpy1.22python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.22python3.10.____cpython.yaml
@@ -13,7 +13,7 @@ cdt_name:
 channel_sources:
 - conda-forge
 channel_targets:
-- conda-forge dev
+- conda-forge cyclus_dev
 coin_or_cbc:
 - '2.10'
 coin_or_cgl:

--- a/.ci_support/linux_64_numpy1.22python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.22python3.9.____cpython.yaml
@@ -13,7 +13,7 @@ cdt_name:
 channel_sources:
 - conda-forge
 channel_targets:
-- conda-forge dev
+- conda-forge cyclus_dev
 coin_or_cbc:
 - '2.10'
 coin_or_cgl:

--- a/.ci_support/linux_64_numpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.23python3.11.____cpython.yaml
@@ -13,7 +13,7 @@ cdt_name:
 channel_sources:
 - conda-forge
 channel_targets:
-- conda-forge dev
+- conda-forge cyclus_dev
 coin_or_cbc:
 - '2.10'
 coin_or_cgl:

--- a/.ci_support/linux_64_numpy1.26python3.12.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.26python3.12.____cpython.yaml
@@ -13,7 +13,7 @@ cdt_name:
 channel_sources:
 - conda-forge
 channel_targets:
-- conda-forge dev
+- conda-forge cyclus_dev
 coin_or_cbc:
 - '2.10'
 coin_or_cgl:

--- a/README.md
+++ b/README.md
@@ -72,14 +72,14 @@ Current release info
 Installing cyclus
 =================
 
-Installing `cyclus` from the `conda-forge/label/dev` channel can be achieved by adding `conda-forge/label/dev` to your channels with:
+Installing `cyclus` from the `conda-forge/label/cyclus_dev` channel can be achieved by adding `conda-forge/label/cyclus_dev` to your channels with:
 
 ```
-conda config --add channels conda-forge/label/dev
+conda config --add channels conda-forge/label/cyclus_dev
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge/label/dev` channel has been enabled, `cyclus` can be installed with `conda`:
+Once the `conda-forge/label/cyclus_dev` channel has been enabled, `cyclus` can be installed with `conda`:
 
 ```
 conda install cyclus
@@ -94,26 +94,26 @@ mamba install cyclus
 It is possible to list all of the versions of `cyclus` available on your platform with `conda`:
 
 ```
-conda search cyclus --channel conda-forge/label/dev
+conda search cyclus --channel conda-forge/label/cyclus_dev
 ```
 
 or with `mamba`:
 
 ```
-mamba search cyclus --channel conda-forge/label/dev
+mamba search cyclus --channel conda-forge/label/cyclus_dev
 ```
 
 Alternatively, `mamba repoquery` may provide more information:
 
 ```
 # Search all versions available on your platform:
-mamba repoquery search cyclus --channel conda-forge/label/dev
+mamba repoquery search cyclus --channel conda-forge/label/cyclus_dev
 
 # List packages depending on `cyclus`:
-mamba repoquery whoneeds cyclus --channel conda-forge/label/dev
+mamba repoquery whoneeds cyclus --channel conda-forge/label/cyclus_dev
 
 # List dependencies of `cyclus`:
-mamba repoquery depends cyclus --channel conda-forge/label/dev
+mamba repoquery depends cyclus --channel conda-forge/label/cyclus_dev
 ```
 
 

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,2 +1,2 @@
 channel_targets:
-  - conda-forge dev
+  - conda-forge cyclus_dev

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   git_rev: main
 
 build:
-  number: 1
+  number: 2
   skip: true  # [win or osx]
   detect_binary_files_with_prefix: true
   preserve_egg_dir: true


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
I made a mistake by having the target label as `dev`, that way when we try to build the cycamore package downstream it not only looks for cyclus in `conda-forge/label/dev` but it also looks for everything else there first (which causes many dependency compatibility issues).  By specifying the target label as `cyclus_dev` we can fetch the development version of **only** the cyclus package (and the `main` versions of our other dependencies).  This strategy more closely aligns with the [example in the conda-forge docs](https://conda-forge.org/docs/maintainer/knowledge_base/#creating-a-pre-release-build).
